### PR TITLE
lssue1～3の修正

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -2,7 +2,7 @@ class CalendarsController < ApplicationController
 
   # １週間のカレンダーと予定が表示されるページ
   def index
-    getWeek
+    get_week
     @plan = Plan.new
   end
 
@@ -18,7 +18,7 @@ class CalendarsController < ApplicationController
     params.require(:calendars).permit(:date, :plan)
   end
 
-  def getWeek
+  def get_week
     wdays = ['(日)','(月)','(火)','(水)','(木)','(金)','(土)']
 
     # Dateオブジェクトは、日付を保持しています。下記のように`.today.day`とすると、今日の日付を取得できます。
@@ -34,7 +34,13 @@ class CalendarsController < ApplicationController
       plans.each do |plan|
         today_plans.push(plan.plan) if plan.date == @todays_date + x
       end
-      days = { :month => (@todays_date + x).month, :date => (@todays_date+x).day, :plans => today_plans}
+
+      days = {
+      month: (@todays_date + x).month, 
+      date: (@todays_date+x).day, 
+      plans: today_plans
+    }
+
       @week_days.push(days)
     end
 

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -12,15 +12,15 @@
     <% @week_days.each do |day| %>
       <div class='item'>
         <div class='date'>
-          <% day[:month] %>/<% day[:date] %>
-        </div>
-        <ul class='content'>
-        <% if day[:plans].length != 0 %>
-          <% day[:plans].each do |plan| %>
-            <li class='plan-list'>・<%= plan %></li>
-          <% end %>
-        <% end %>
-        </ul>
+  <%= day[:month] %>/<%= day[:date] %>
+</div>
+<ul class='content'>
+  <% if day[:plans].any? %>
+    <% day[:plans].each do |plan| %>
+      <li class='plan-list'>・<%= plan %></li>
+    <% end %>
+  <% end %>
+</ul>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
Lesson1～3の解消
## WHAT
- ハッシュロケット記法（=>）をシンボル型に修正
- getWeek → get_week にメソッド名を修正（命名規則の統一）
- calendars_controller.rb の不要なタグ・構文を整理

## WHY
- 可読性・保守性を向上させるため
- Rubyの命名規則に沿って、開発者間で統一されたコードを書くため
- 今後の機能追加・レビューをスムーズにするため

以上の修正をsecond_trinigで行いましたのでご確認お願いいたします。